### PR TITLE
Add pci_score.json for Percona Server for PostgreSQL

### DIFF
--- a/postgres-compatibility-index/outputs/Percona.json
+++ b/postgres-compatibility-index/outputs/Percona.json
@@ -1,0 +1,68 @@
+{
+    "pci_score": 100,
+    "details": {
+        "data_types": {
+            "Primitive Types": "full",
+            "Complex Types": "full",
+            "JSONB": "full",
+            "Geospatial Types": "full",
+            "Custom Types": "full",
+            "Full-Text Search": "full",
+            "Vector": "full"
+        },
+        "DDL_features": {
+            "Schemas": "full",
+            "Sequences": "full",
+            "Views": "full",
+            "Materialized Views": "full"
+        },
+        "SQL_features": {
+            "CTEs": "full",
+            "Upsert": "full",
+            "Window Functions": "full",
+            "Subqueries": "full"
+        },
+        "procedural_features": {
+            "Stored Procedures": "full",
+            "Functions": "full",
+            "Triggers": "full"
+        },
+        "performance": {
+            "Index Types": "full",
+            "Partitioning": "full",
+            "Parallel Query Execution": "full",
+            "Unlogged Table": "full"
+        },
+        "constraints": {
+            "Foreign Key": "full",
+            "Check": "full",
+            "Not Null": "full",
+            "Unique": "full",
+            "Exclusion": "full"
+        },
+        "extensions": {
+            "Extension Support": "full",
+            "Foreign Data Wrappers": "full"
+        },
+        "security": {
+            "Role Management": "full",
+            "GRANT/REVOKE Privileges": "full",
+            "Row-Level Security": "full"
+        },
+        "replication": {
+            "Streaming Replication": "full",
+            "Logical Replication": "full"
+        },
+        "transaction_features": {
+            "ACID Compliance": "full",
+            "Isolation Levels": "full",
+            "Nested Transactions": "full",
+            "Row-Level Locking": "full"
+        },
+        "miscellaneous": {
+            "pg_stat_statements": "full",
+            "pg_walinspect": "full",
+            "External Programming Language": "full"
+        }
+    }
+}


### PR DESCRIPTION
The score was taken against Percona Server for PostgreSQL 17.6.1